### PR TITLE
Basic python3 compatibility

### DIFF
--- a/1Password 6/OnePasswordURLProvider.py
+++ b/1Password 6/OnePasswordURLProvider.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 from __future__ import absolute_import
+
 import json
 
 from autopkglib import Processor, ProcessorError

--- a/1Password 6/OnePasswordURLProvider.py
+++ b/1Password 6/OnePasswordURLProvider.py
@@ -57,7 +57,7 @@ class OnePasswordURLProvider(Processor):
         try:
             f = urlopen(base_url)
             json_data = json.load(f)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (base_url, e))
 
         return json_data

--- a/1Password 6/OnePasswordURLProvider.py
+++ b/1Password 6/OnePasswordURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 #
+from __future__ import absolute_import
 import urllib2
 import json
 

--- a/1Password 6/OnePasswordURLProvider.py
+++ b/1Password 6/OnePasswordURLProvider.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 #
 from __future__ import absolute_import
-import urllib2
 import json
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["OnePasswordURLProvider"]
 
@@ -51,7 +54,7 @@ class OnePasswordURLProvider(Processor):
     def download_update_info(self, base_url):
         """Downloads the update url and returns a json object"""
         try:
-            f = urllib2.urlopen(base_url)
+            f = urlopen(base_url)
             json_data = json.load(f)
         except BaseException as e:
             raise ProcessorError("Can't download %s: %s" % (base_url, e))


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.