### PR TITLE
Deprecate 1Password 6 recipes

### DIFF
--- a/1Password 6/1Password6.download.recipe
+++ b/1Password 6/1Password6.download.recipe
@@ -21,6 +21,15 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>1Password 6 is no longer available (details: https://1password.community/discussion/104999/1password-6-legacy-support-information). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>OnePasswordURLProvider</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
1Password 6 is no longer supported by AgileBits. This PR deprecates the 1Password 6 recipes in this repo.
