### PR TITLE
Update README with branch name change notice from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # kitzy-recipes
+
+## ⚠️ Important Notice - Branch Name Change (September 26, 2025)
+
+The default branch for this repository has been changed from `master` to `main`. If you are currently using these recipes, you will need to update your local AutoPkg repository configuration:
+
+```bash
+autopkg repo-delete kitzy-recipes
+autopkg repo-add kitzy-recipes
+```
+
+This will ensure you receive future updates from the correct branch.


### PR DESCRIPTION
Add a notice in the README to inform users about the change of the default branch name from `master` to `main`, along with instructions to update their local AutoPkg repository configuration.