### PR TITLE
Fix AppPkgCreator app_path for Claude recipe

### DIFF
--- a/Anthropic/Claude.pkg.recipe.yaml
+++ b/Anthropic/Claude.pkg.recipe.yaml
@@ -6,3 +6,5 @@ MinimumVersion: '2.3'
 ParentRecipe: com.github.almenscorner.download.Claude
 Process:
 - Processor: AppPkgCreator
+  Arguments:
+    app_path: '%RECIPE_CACHE_DIR%/%NAME%.app'


### PR DESCRIPTION
AppPkgCreator defaults to globbing pathname/*.app, but pathname is set by URLDownloader to the zip file path. This causes 'Error processing path ...downloads/Claude.zip/*.app with glob' since the app is extracted to RECIPE_CACHE_DIR by the parent download recipe's Unarchiver step.

Explicitly set app_path to %RECIPE_CACHE_DIR%/%NAME%.app so AppPkgCreator finds the extracted Claude.app.